### PR TITLE
Change cpu governer

### DIFF
--- a/modules/physical.nix
+++ b/modules/physical.nix
@@ -24,7 +24,7 @@
 
     powerManagement =
       { enable = true;
-        cpuFreqGovernor = "performance";
+        cpuFreqGovernor = "ondemand";
       };
 
     hardware.firmware = with pkgs; [ firmwareLinuxNonfree ];


### PR DESCRIPTION
Using performance *limits* the cpufreq to the highest non-turbo frequency. The setting should be "ondemand", which will fall back to "powersave" if unavailable. Powersave enables power management on newer intel chips and (as a side effect and contrary to the name) enables turbo modes. You'll also have a higher chance of hitting thermal throttling.

The performance should not be used except for old hardware (or on older kernels) where power management caused additional latencies.

I'm not sure if this is the case here, but there is a considerable chance that this setting is _limiting_/_throttling_ the CPU.