### PR TITLE
For DHCPv4, it changes the behaviour from strict RFC compliance so that

### DIFF
--- a/modules/gateway.nix
+++ b/modules/gateway.nix
@@ -457,6 +457,7 @@ in
               server=2001:608:a01::53
 
               enable-tftp
+              dhcp-authoritative
               tftp-root=/var/lib/tftp
               tftp-secure
               dhcp-match=set:ipxe,175


### PR DESCRIPTION
DHCP requests on unknown leases from unknown hosts are not ignored. This
allows new hosts to get a lease without a tedious timeout under all
circumstances